### PR TITLE
find faq anchor

### DIFF
--- a/faq.py
+++ b/faq.py
@@ -1,11 +1,14 @@
 from collections import OrderedDict
 import re
 
+ANCHOR_BIGQUERY = None
+
 def get_anchor(question):
     return question.lower().replace(' ', '-').replace('?', '').replace('\'', '')
 
 def load_faq():
     global FAQ
+    global ANCHOR_BIGQUERY
     global anchors
 
     with open('docs/faq.md') as faq_file:
@@ -14,5 +17,14 @@ def load_faq():
         # Any heading-level markdown (#, ##, etc) is assumed to be a question.
         questions = re.findall(r'^[#]+\s*(.*)', FAQ, flags=re.MULTILINE)
         anchors = OrderedDict((question, get_anchor(question)) for question in questions)
+        ANCHOR_BIGQUERY = find_anchor('BigQuery')
+
+# Finds the first anchor whose question contains a given string.
+def find_anchor(query):
+	global anchors
+	questions = [question for question in anchors if query.lower() in question.lower()]
+	if len(questions):
+		return anchors.get(questions[0])
+	return None
 
 load_faq()

--- a/main.py
+++ b/main.py
@@ -28,7 +28,8 @@ Markdown(app)
 def index():
     return render_template('index.html',
                            reports=reportutil.get_reports(),
-                           featured_reports=reportutil.get_featured_reports())
+                           featured_reports=reportutil.get_featured_reports(),
+                           faq=faqutil)
 
 @app.route('/about')
 def about():

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,9 @@
 {% block main %}
 	<section id="how-web-is-built" class="container">
 		<div class="col-lg-5 col-sm-5 col-md-5 col-xs-6">
-			<img src="/static/img/web.png" alt=""/>
+			<a href="{{ url_for('reports') }}">
+				<img src="/static/img/web.png" alt="" aria-label="HTTP Archive reports"/>
+			</a>
 		</div>
 
 		<div class="col-lg-7 col-sm-7 col-md-7 col-xs-12">
@@ -63,11 +65,13 @@
 					The HTTP Archive archives and provides access to detailed information about each website it crawls: request and response metadata, response bodies, execution traces, and more. You can download this data for offline analysis, or access it as a public dataset via Google BigQuery for fast and rapid analysis. 
 				</p>
 
-				<a href="{{ url_for('faq') }}" class="btn">Learn More</a>
+				<a href="{{ url_for('faq', _anchor=faq.ANCHOR_BIGQUERY) }}" class="btn">Learn More</a>
 			</div>
 
 			<div class="col-lg-6 col-sm-6 col-md-6 hidden-xs">
-				<img src="/static/img/data.png" alt=""/>
+				<a href="{{ url_for('faq', _anchor=faq.ANCHOR_BIGQUERY) }}">
+					<img src="/static/img/data.png" alt="" aria-label="Learn more about HTTP Archive on BigQuery"/>
+				</a>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Small improvement to link directly to the FAQ about BigQuery from the home page section about BigQuery. Since the FAQ is generated from markdown, we need to search for the question first and pass its corresponding anchor to the link on the home page.

Also ensure all big graphics on the home page are clickable links.